### PR TITLE
updates duplicate dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER "Daniel Whatmuff" <danielwhatmuff@gmail.com>
 COPY yum.conf /etc/yum.conf
 
 RUN yum clean all && \
-    yum -y install python27-pip python27-devel python27-virtualenv vim postgresql postgresql-devel mysql mysql-devel gcc && \
+    yum -y install python27-devel python27-virtualenv vim postgresql postgresql-devel mysql mysql-devel gcc && \
     pip install -U pip && \
-    pip install -U zappa mysql-python awscli
+    pip install -U zappa mysql-python
 
 WORKDIR /var/task
 


### PR DESCRIPTION
python27-pip is an automatically downloaded dependency from python27-devel and awscli already comes with zappa