### PR TITLE
Remove packages for scipy, h5py, and pyyaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ MAINTAINER "Daniel Whatmuff" <danielwhatmuff@gmail.com>
 COPY yum.conf /etc/yum.conf
 
 RUN yum clean all && \
-    yum -y install python27-devel python27-virtualenv vim postgresql postgresql-devel mysql mysql-devel gcc lapack-devel blas-devel libyaml-devel && \
-    yum --enablerepo=epel -y install hdf5-devel && \
+    yum -y install python27-devel python27-virtualenv vim postgresql postgresql-devel mysql mysql-devel gcc && \
     pip install -U pip && \
     pip install -U zappa mysql-python
 


### PR DESCRIPTION
Can't deploy AWS Lambda packages with Tensorflow as it exceeds the size limit.